### PR TITLE
Migrate GitHub Pages build to Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,12 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.28.3-x64-mingw-ucrt)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -59,6 +63,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.81.0-x64-mingw-ucrt)
       google-protobuf (~> 4.28)
+    sass-embedded (1.81.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.28)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -66,6 +72,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,12 @@ Currently it uses Jekyll
 
 ### Local development
 
-Run `jekyll serve` to start a development server.
+Run `bundle exec jekyll serve` to start a development server.
+
+### Deployment
+
+The site is built with Jekyll and deployed to GitHub Pages with GitHub Actions.
+
+After merging the Pages workflow, set the repository Pages source to **GitHub Actions**:
+
+https://github.com/TimStewartJ/personal-site/settings/pages

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+title: TimStewartJ
+url: "https://timstewartj.com"
+baseurl: ""
+permalink: /:categories/:year/:month/:day/:title:output_ext
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - vendor/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TimStewartJ</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400" rel="stylesheet" type="text/css" />
-    <link rel="stylesheet" href="/assets/css/style.css" />
-    <link rel="shortcut icon" type="image/x-icon" href="/assets/favicon/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon/favicon-16x16.png" />
-    <link rel="manifest" href="/assets/site.webmanifest" />
+    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" />
+    <link rel="shortcut icon" type="image/x-icon" href="{{ "/assets/favicon/favicon.ico" | relative_url }}" />
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ "/assets/favicon/apple-touch-icon.png" | relative_url }}" />
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/favicon/favicon-32x32.png" | relative_url }}" />
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ "/assets/favicon/favicon-16x16.png" | relative_url }}" />
+    <link rel="manifest" href="{{ "/assets/site.webmanifest" | relative_url }}" />
   </head>
 
   <body>
@@ -22,17 +22,17 @@ The fixed header
 
       <div class="headerholder">
         <div class="header">
-          <img src="/assets/images/OffProf.png" id="headimg" /><img src="/assets/images/Logo.png" id="logoimg" />
+          <img src="{{ "/assets/images/OffProf.png" | relative_url }}" id="headimg" /><img src="{{ "/assets/images/Logo.png" | relative_url }}" id="logoimg" />
           <div id="headtitle">
-            <h1><a href="/">Tim Stewart</a></h1>
+            <h1><a href="{{ "/" | relative_url }}">Tim Stewart</a></h1>
           </div>
 
           <nav>
-            <a href="/">Home</a>
-            <a href="/projects">Projects</a>
+            <a href="{{ "/" | relative_url }}">Home</a>
+            <a href="{{ "/projects" | relative_url }}">Projects</a>
             <!-- <a href="/portfolio">Portfolio</a> -->
-            <a href="/social">Social</a>
-            <a href="/assets/Resume.pdf" target="_blank" rel="noreferrer noopener">Resume</a>
+            <a href="{{ "/social" | relative_url }}">Social</a>
+            <a href="{{ "/assets/Resume.pdf" | relative_url }}" target="_blank" rel="noreferrer noopener">Resume</a>
           </nav>
         </div>
       </div>

--- a/_posts/2016-01-01-elliptical-illusion.html
+++ b/_posts/2016-01-01-elliptical-illusion.html
@@ -6,7 +6,7 @@ desc: A quick 2D game made for a game jam in early Summer of 2020.
 external_url: https://334.itch.io/elliptical-illusion
 ---
 
-<img src="{{ url_for('static', filename='images/thumbnails/ellill.png') }}" />
+<img src="{{ "/assets/images/thumbnails/ellill.png" | relative_url }}" />
 <p class="desc">A quick 2D game made for a game jam in early Summer of 2020.</p>
 
 <h2>About the Project</h2>

--- a/_posts/2016-01-01-getsac-html.html
+++ b/_posts/2016-01-01-getsac-html.html
@@ -6,7 +6,7 @@ desc: A simple 2D game that won 1st in Game Development at SacHacks III.
 external_url: https://getsac.online
 ---
 
-<img src="{{ url_for('static', filename='images/thumbnails/getsac.png') }}" />
+<img src="{{ "/assets/images/thumbnails/getsac.png" | relative_url }}" />
 <p class="desc">A simple 2D game that won 1st in Game Development at SacHacks III.</p>
 
 <h2>About the Project</h2>

--- a/_posts/2016-01-01-schedule-builder.html
+++ b/_posts/2016-01-01-schedule-builder.html
@@ -6,7 +6,7 @@ desc: A tool that will automatically generate schedules given an input of classe
 external_url: https://timstewartj.github.io/UCDScheduleBuilder/
 ---
 
-<img src="{{ url_for('static', filename='images/thumbnails/ucdschgen.png') }}" />
+<img src="{{ "/assets/images/thumbnails/ucdschgen.png" | relative_url }}" />
 <p class="desc">A tool that will automatically generate schedules given an input of classes.</p>
 
 <h2>About the Project</h2>

--- a/_posts/2025-06-03-youtube-summarizer.html
+++ b/_posts/2025-06-03-youtube-summarizer.html
@@ -11,7 +11,7 @@ categories: [projects, browser-extension, productivity, ai]
 <p><strong>A Firefox extension that instantly summarizes YouTube videos using Google's Gemini AI.</strong></p>
 
 <video autoplay loop muted>
-  <source src="/assets/images/thumbnails/YtExtensionHero.webm" type="video/webm">
+  <source src="{{ "/assets/images/thumbnails/YtExtensionHero.webm" | relative_url }}" type="video/webm">
 </video>
 
 <h2>The Problem</h2>

--- a/projects.html
+++ b/projects.html
@@ -12,7 +12,7 @@ title: Projects
   <div class="projects">
     {% for post in site.posts %}
 
-    <a class="section project" href="{{ post.external_url | default: post.url }}" {% if post.external_url
+    <a class="section project" href="{% if post.external_url %}{{ post.external_url }}{% else %}{{ post.url | relative_url }}{% endif %}" {% if post.external_url
       %}target="_blank" rel="noopener noreferrer" {% endif %}>
       {% if post.external_url %}
       <div class="external-link-indicator" aria-label="Opens in new tab">
@@ -35,10 +35,10 @@ title: Projects
       {% assign extension = file_parts | last %}
       {% if extension == 'webm' %}
       <video class="thumbnail" autoplay loop muted aria-label="{{ post.title }}">
-        <source src="{{ post.thumb_link }}" type="video/webm">
+        <source src="{{ post.thumb_link | relative_url }}" type="video/webm">
       </video>
       {% else %}
-      <img class="thumbnail" src="{{ post.thumb_link }}" aria-label="{{ post.title }}" />
+      <img class="thumbnail" src="{{ post.thumb_link | relative_url }}" aria-label="{{ post.title }}" />
       {% endif %}
       {% endif %}
       {% if post.iframe %}


### PR DESCRIPTION
## Summary

- Add `_config.yml` for explicit Jekyll production settings.
- Add a GitHub Actions workflow to build Jekyll and deploy the generated site artifact to GitHub Pages from `main`.
- Convert root-relative layout/project asset links to `relative_url` so future preview builds can run under a subpath like `/previews/site-refresh/`.
- Add the Linux platform to `Gemfile.lock` for CI dependency installs.
- Clean up three old project posts that used Flask-style `url_for(...)` image paths and caused Jekyll Liquid warnings.
- Document the deployment flow in `README.md`.

## Validation

- `git diff --check`
- Production-style Jekyll build in Docker: `JEKYLL_ENV=production bundle exec jekyll build`
- Preview-style Jekyll build in Docker: `JEKYLL_ENV=production bundle exec jekyll build --baseurl "/previews/site-refresh" --destination _site_preview`
- Checked preview output for root-path leaks in internal assets/nav links.

## Post-merge step

After merging, switch the repo Pages source from legacy branch deploy to GitHub Actions:

`Settings → Pages → Build and deployment → Source → GitHub Actions`

Direct link: https://github.com/TimStewartJ/personal-site/settings/pages

Production should remain `https://timstewartj.com/`. Future preview support can build on this by deploying a full Pages artifact that includes production plus a `/previews/<branch>/` subtree.