### PR TITLE
Add branch preview deployment workflow

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -69,6 +69,10 @@ jobs:
           ref: ${{ steps.preview.outputs.ref }}
           path: _preview_source
 
+      - name: Install preview dependencies
+        working-directory: _preview_source
+        run: bundle install
+
       - name: Build preview site
         working-directory: _preview_source
         run: |

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -91,7 +91,7 @@ jobs:
 
   deploy:
     environment:
-      name: github-pages
+      name: github-pages-preview
       url: ${{ needs.build.outputs.preview_url }}
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-      - infra/**
   workflow_dispatch:
     inputs:
       preview_ref:

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,99 @@
+name: Deploy Branch Preview
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - infra/**
+  workflow_dispatch:
+    inputs:
+      preview_ref:
+        description: Branch or ref to preview
+        required: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.preview.outputs.url }}
+
+    steps:
+      - name: Checkout production source
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Resolve preview path
+        id: preview
+        env:
+          PREVIEW_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.preview_ref || github.ref_name }}
+          PAGES_BASE_URL: ${{ steps.pages.outputs.base_url }}
+        run: |
+          set -euo pipefail
+          slug="$(printf '%s' "$PREVIEW_REF" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g; s#^-+|-+$##g')"
+          if [ -z "$slug" ]; then
+            echo "Preview ref produced an empty URL slug: $PREVIEW_REF" >&2
+            exit 1
+          fi
+          echo "ref=$PREVIEW_REF" >> "$GITHUB_OUTPUT"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          echo "baseurl=/previews/$slug" >> "$GITHUB_OUTPUT"
+          echo "url=$PAGES_BASE_URL/previews/$slug/" >> "$GITHUB_OUTPUT"
+
+      - name: Build production site
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Checkout preview source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.preview.outputs.ref }}
+          path: _preview_source
+
+      - name: Build preview site
+        working-directory: _preview_source
+        run: |
+          set -euo pipefail
+          bundle exec jekyll build \
+            --baseurl "${{ steps.preview.outputs.baseurl }}" \
+            --destination "../_site/previews/${{ steps.preview.outputs.slug }}"
+          rm -f "../_site/previews/${{ steps.preview.outputs.slug }}/CNAME"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ needs.build.outputs.preview_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ The site is built with Jekyll and deployed to GitHub Pages with GitHub Actions.
 After merging the Pages workflow, set the repository Pages source to **GitHub Actions**:
 
 https://github.com/TimStewartJ/personal-site/settings/pages
+
+### Branch previews
+
+Branches other than `main` and `infra/**` are deployed as previews under `/previews/<branch-slug>/`.
+
+For example, pushing a branch named `site-refresh` creates:
+
+https://timstewartj.com/previews/site-refresh/
+
+The preview workflow builds the production root from `main`, then builds the preview branch into the preview subdirectory before deploying one combined GitHub Pages artifact.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/TimStewartJ/personal-site/settings/pages
 
 ### Branch previews
 
-Branches other than `main` and `infra/**` are deployed as previews under `/previews/<branch-slug>/`.
+Branches other than `main` are deployed as previews under `/previews/<branch-slug>/`.
 
 For example, pushing a branch named `site-refresh` creates:
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ For example, pushing a branch named `site-refresh` creates:
 https://timstewartj.com/previews/site-refresh/
 
 The preview workflow builds the production root from `main`, then builds the preview branch into the preview subdirectory before deploying one combined GitHub Pages artifact.
+
+A later production deploy from `main` replaces the published Pages artifact, so rerun the preview workflow or push the preview branch again if a preview URL disappears after a production deploy.


### PR DESCRIPTION
## Summary

- Add a branch preview workflow for GitHub Pages.
- For preview deployments, build the production root from `main` and build the preview branch under `/previews/branch-slug/`.
- Deploy one combined Pages artifact so `timstewartj.com/` stays rooted at `main` while the preview URL shows branch content.
- Ignore only `main` pushes so all feature/infra branches can be dogfooded as previews.
- Use a separate `github-pages-preview` Actions environment so preview branches are not blocked by the production `github-pages` environment branch policy.
- Document preview URLs and behavior in the README.

## Preview URL behavior

A branch named `site-refresh` will deploy to:

`https://timstewartj.com/previews/site-refresh/`

Branches with slashes are slugged, so `feature/homepage-refresh` becomes:

`https://timstewartj.com/previews/feature-homepage-refresh/`

## Validation

- `git diff --check`
- Built a combined artifact locally in Docker:
  - production root via `JEKYLL_ENV=production bundle exec jekyll build`
  - preview subtree via `JEKYLL_ENV=production bundle exec jekyll build --baseurl "/previews/site-refresh" --destination _site/previews/site-refresh`
- Verified root `CNAME` exists and nested preview `CNAME` is removed.
- Checked preview output for root-path leaks in internal assets/nav links.
- Dogfooded the workflow from this branch: https://github.com/TimStewartJ/personal-site/actions/runs/25409055814
- Confirmed the preview URL returns 200: `https://timstewartj.com/previews/infra-pages-branch-previews/`
- Confirmed preview assets resolve under the preview base path.

## Notes

The official GitHub Pages deploy action replaces the full published artifact on each deployment. This workflow keeps production safe by always rebuilding the root from `main` before adding the preview subtree.

A later production deploy from `main` can clear preview folders because it deploys a production-only artifact. If a preview disappears after a production deploy, rerun the preview workflow manually or push the preview branch again.