### PR TITLE
Clean up basic site accessibility

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -46,7 +46,7 @@
   {% endif %}
 
   {% if project.iframe %}
-  <iframe class="project-iframe" src="{{ project.iframe }}" title="{{ project.title }}" frameborder="0" allowfullscreen></iframe>
+  <iframe class="project-iframe" src="{{ project.iframe }}" title="{{ project.title }} preview" frameborder="0" allowfullscreen tabindex="-1" aria-hidden="true"></iframe>
   {% endif %}
 
   <p class="desc">{{ project.desc }}</p>

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -37,16 +37,16 @@
   {% assign file_parts = project.thumb_link | split: '.' %}
   {% assign extension = file_parts | last %}
   {% if extension == 'webm' %}
-  <video class="thumbnail" autoplay loop muted aria-label="{{ project.title }}">
+  <video class="thumbnail" autoplay loop muted playsinline aria-hidden="true">
     <source src="{{ project.thumb_link | relative_url }}" type="video/webm">
   </video>
   {% else %}
-  <img class="thumbnail" src="{{ project.thumb_link | relative_url }}" aria-label="{{ project.title }}" />
+  <img class="thumbnail" src="{{ project.thumb_link | relative_url }}" alt="" />
   {% endif %}
   {% endif %}
 
   {% if project.iframe %}
-  <iframe class="project-iframe" src="{{ project.iframe }}" frameborder="0" allowfullscreen></iframe>
+  <iframe class="project-iframe" src="{{ project.iframe }}" title="{{ project.title }}" frameborder="0" allowfullscreen></iframe>
   {% endif %}
 
   <p class="desc">{{ project.desc }}</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,12 +23,12 @@ The fixed header
 
       <div class="headerholder">
         <div class="header">
-          <img src="{{ "/assets/images/OffProf.png" | relative_url }}" id="headimg" /><img src="{{ "/assets/images/Logo.png" | relative_url }}" id="logoimg" />
+          <img src="{{ "/assets/images/OffProf.png" | relative_url }}" id="headimg" alt="" aria-hidden="true" /><img src="{{ "/assets/images/Logo.png" | relative_url }}" id="logoimg" alt="" aria-hidden="true" />
           <div id="headtitle">
             <h1><a href="{{ "/" | relative_url }}">Tim Stewart</a></h1>
           </div>
 
-          <nav>
+          <nav aria-label="Primary">
             <a href="{{ "/" | relative_url }}">Home</a>
             <a href="{{ "/projects" | relative_url }}">Projects</a>
             <a href="{{ "/social" | relative_url }}">Social</a>


### PR DESCRIPTION
## Summary

A small maintenance pass from `main` that keeps the original site design intact.

- Mark decorative header images as hidden from assistive tech
- Label the primary navigation landmark
- Make project-card thumbnails/videos decorative so card links do not repeat the project title
- Hide decorative embedded project previews from assistive tech and remove them from tab order

## Preview

Home:
https://timstewartj.com/previews/site-basics-cleanup/?v=211898e

Projects:
https://timstewartj.com/previews/site-basics-cleanup/projects/?v=211898e

## Validation

- Built the production Jekyll site locally
- Verified generated route files for Home, Projects, Social, Resume, sitemap, robots, and the resume PDF
- Verified live preview includes labeled primary nav and decorative header image attributes
- Verified live Projects preview no longer repeats project media labels in card links