### PR TITLE
Reorganize project sections

### DIFF
--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -95,6 +95,11 @@ height: 600px;
 	flex: 1 1 100%;
 }
 
+.projects-page .project-section p {
+	margin: 0.25rem 0 1rem;
+	width: auto;
+}
+
 .footer {
 	height: 100px;
 }

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -10,6 +10,11 @@
 	width: 56%;
 }
 
+.projects-page .section.wide,
+.projects-page .projects {
+	width: min(64rem, calc(100% - 2rem));
+}
+
 .hero h1 {
 	font-size: 3em;
 	line-height: 1.1em;
@@ -74,11 +79,23 @@
 	margin-top: 1em;
 }
 
+.projects-page .projects + .project-section {
+	margin-top: 3rem;
+}
+
+.projects-page .project-section p {
+	color: #adadad;
+	margin: 0.25rem 0 1rem;
+	max-width: 42rem;
+	width: auto;
+}
+
 .project {
 	margin: 0;
 	padding: 1em;
 	border: 1px solid rgba(197, 198, 199, 0.16);
 	border-radius: 0.2em;
+	box-sizing: border-box;
 	flex: 1 1 16rem;
 	min-width: 0;
 	background-color: rgba(20, 22, 29, 0.45);
@@ -100,6 +117,7 @@
 
 .post-date {
 	font-style: italic;
+	margin: 0.5rem 0;
 }
 
 .project-meta {
@@ -124,12 +142,17 @@
 .project h2{
 	color:rgb(101, 212, 205);
 	margin-top: 0;
+	margin-bottom: 0.35rem;
 }
 
 .desc {
 	color: #adadad;
 	line-height: 1.55em;
 	margin-bottom: 0;
+}
+
+.project .desc {
+	margin-top: 0.75rem;
 }
 
 /* External link indicator */

--- a/projects.html
+++ b/projects.html
@@ -8,7 +8,7 @@ permalink: /projects/
 {% assign selected_project_titles = "YouTube Summarizer with Gemini|GluChart" | split: "|" %}
 {% assign hidden_project_titles = "Career Expo Project" | split: "|" %}
 
-<div class="content">
+<div class="content projects-page">
   <div class="section wide">
     <h1>Projects</h1>
   </div>

--- a/projects.html
+++ b/projects.html
@@ -4,28 +4,48 @@ title: Projects
 permalink: /projects/
 ---
 
+{% assign current_project_titles = "Copilot Bridge|Mineless|Circles" | split: "|" %}
+{% assign selected_project_titles = "YouTube Summarizer with Gemini|GluChart" | split: "|" %}
+{% assign hidden_project_titles = "Career Expo Project" | split: "|" %}
+
 <div class="content">
   <div class="section wide">
     <h1>Projects</h1>
   </div>
 
   <div class="section wide project-section">
-    <h2>Active</h2>
+    <h2>Current</h2>
+    <p>Things I am actively building, shaping, using, or deciding the future of.</p>
   </div>
   <div class="projects">
-    {% for post in site.posts %}
-      {% if post.featured %}
-        {% include project-card.html project=post %}
+    {% for project_title in current_project_titles %}
+      {% assign project = site.posts | where: "title", project_title | first %}
+      {% if project %}
+        {% include project-card.html project=project %}
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <div class="section wide project-section">
+    <h2>Selected Work</h2>
+    <p>Finished or stable projects that still feel representative of what I like to make.</p>
+  </div>
+  <div class="projects">
+    {% for project_title in selected_project_titles %}
+      {% assign project = site.posts | where: "title", project_title | first %}
+      {% if project %}
+        {% include project-card.html project=project %}
       {% endif %}
     {% endfor %}
   </div>
 
   <div class="section wide project-section">
     <h2>Archive</h2>
+    <p>Older, smaller, or more nostalgic things I still want to keep around.</p>
   </div>
   <div class="projects">
     {% for post in site.posts %}
-      {% unless post.featured %}
+      {% unless current_project_titles contains post.title or selected_project_titles contains post.title or hidden_project_titles contains post.title %}
         {% include project-card.html project=post %}
       {% endunless %}
     {% endfor %}


### PR DESCRIPTION
## Summary

- Split the Projects page into Current, Selected Work, and Archive sections.
- Keep current work focused on Copilot Bridge, Mineless, and Circles.
- Move YouTube Summarizer and GluChart into Selected Work.
- Hide the old Career Expo item from the Projects index.
- Polish Projects page spacing while keeping the existing flex card layout.

## Validation

- Built the production Jekyll site from the upstream branch in a Ruby Docker container.
- Verified generated Projects headings are Current, Selected Work, and Archive.
- Verified Career Expo no longer appears on the generated Projects page.
- Verified the branch preview deployed with the updated Projects CSS.