### PR TITLE
Add phase 1 visual foundation

### DIFF
--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -5,7 +5,7 @@
   {% assign project_href = project.url | relative_url %}
 {% endif %}
 
-<a class="section project" href="{{ project_href }}" {% if project.external_url %}target="_blank" rel="noopener noreferrer" {% endif %}>
+<a class="project-card" href="{{ project_href }}" {% if project.external_url %}target="_blank" rel="noopener noreferrer" {% endif %}>
   {% if project.external_url %}
   <div class="external-link-indicator" aria-label="Opens in new tab">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
@@ -20,7 +20,7 @@
   <h2>{{ project.title }}</h2>
 
   {% if project.status or project.project_type %}
-  <p class="project-meta">
+  <p class="project-card__meta">
     {% if project.status %}<span>{{ project.status }}</span>{% endif %}
     {% if project.status and project.project_type %}<span aria-hidden="true">/</span>{% endif %}
     {% if project.project_type %}<span>{{ project.project_type }}</span>{% endif %}
@@ -28,9 +28,12 @@
   {% endif %}
 
   {% if project.start_date and project.end_date %}
-  <p class="post-date">{{ project.start_date | date: "%B %d, %Y" }} - {{ project.end_date | date: "%B %d, %Y" }}</p>
+  <p class="project-card__date">
+    {{ project.start_date | date: "%B %d, %Y" }} -
+    {% if project.end_date == "Present" %}Present{% else %}{{ project.end_date | date: "%B %d, %Y" }}{% endif %}
+  </p>
   {% elsif project.start_date %}
-  <p class="post-date">{{ project.start_date | date: "%B %d, %Y" }}</p>
+  <p class="project-card__date">{{ project.start_date | date: "%B %d, %Y" }}</p>
   {% endif %}
 
   {% if project.thumb_link %}
@@ -50,4 +53,5 @@
   {% endif %}
 
   <p class="desc">{{ project.desc }}</p>
+  <span class="project-card__cta">{% if project.external_url %}Open project{% else %}Read more{% endif %}</span>
 </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0b0c10" />
     <title>{% if page.title %}{{ page.title }} | {% endif %}TimStewartJ</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400" rel="stylesheet" type="text/css" />
-    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}" />
+    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}?v={{ site.time | date: '%s' }}" />
     <link rel="shortcut icon" type="image/x-icon" href="{{ "/assets/favicon/favicon.ico" | relative_url }}" />
     <link rel="apple-touch-icon" sizes="180x180" href="{{ "/assets/favicon/apple-touch-icon.png" | relative_url }}" />
     <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/favicon/favicon-32x32.png" | relative_url }}" />
@@ -16,37 +16,28 @@
 
   <body>
     <div class="container">
-      <!-- 
-Beginning of actual display
-The fixed header
--->
-
       <div class="headerholder">
-        <div class="header">
+        <header class="header">
           <div class="site-brand">
             <img src="{{ "/assets/images/OffProf.png" | relative_url }}" id="headimg" alt="" aria-hidden="true" />
-            <div id="headtitle">
-              <h1><a href="{{ "/" | relative_url }}">Tim Stewart</a></h1>
-            </div>
+            <a class="site-brand__title" href="{{ "/" | relative_url }}">Tim Stewart</a>
           </div>
 
           <nav aria-label="Primary">
-            <a href="{{ "/" | relative_url }}">Home</a>
-            <a href="{{ "/projects" | relative_url }}">Projects</a>
-            <a href="{{ "/social" | relative_url }}">Social</a>
-            <a href="{{ "/resume" | relative_url }}">Resume</a>
+            <a href="{{ "/" | relative_url }}" {% if page.url == "/" %}aria-current="page"{% endif %}>Home</a>
+            <a href="{{ "/projects" | relative_url }}" {% if page.url contains "/projects" %}aria-current="page"{% endif %}>Projects</a>
+            <a href="{{ "/social" | relative_url }}" {% if page.url contains "social" %}aria-current="page"{% endif %}>Social</a>
+            <a href="{{ "/resume" | relative_url }}" {% if page.url contains "/resume" %}aria-current="page"{% endif %}>Resume</a>
           </nav>
-        </div>
+        </header>
       </div>
 
       {{content}}
 
-      <!-- The Footer -->
-
-      <div class="footer">
-        <h1>The End</h1>
+      <footer class="footer">
+        <p class="footer__title">The End</p>
         <p>All rights reserved {{ site.time | date: '%Y' }}.</p>
-      </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,39 +1,111 @@
-/* Base styles */
+:root {
+	--color-bg: #0b0c10;
+	--color-surface: #14161d;
+	--color-surface-lift: #191b23;
+	--color-text: #c5c6c7;
+	--color-text-strong: rgba(255, 255, 255, 0.92);
+	--color-muted: #adadad;
+	--color-meta: #8a8b8d;
+	--color-border: rgba(197, 198, 199, 0.16);
+	--color-border-soft: rgba(197, 198, 199, 0.08);
+	--color-accent: #66fcf1;
+	--color-accent-mid: #65d4cd;
+	--color-accent-deep: #45a29e;
+	--color-accent-muted: #9bd9d6;
+	--color-accent-wash: rgba(102, 252, 241, 0.1);
+	--color-accent-ring: rgba(102, 252, 241, 0.35);
+	--font-display: 'Iowan Old Style', 'Charter', 'Georgia', serif;
+	--font-body: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+	--font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+	--space-xs: 0.35rem;
+	--space-sm: 0.65rem;
+	--space-md: 1rem;
+	--space-lg: 1.5rem;
+	--space-xl: 2.5rem;
+	--space-2xl: 4rem;
+	--radius-sm: 0.25rem;
+	--radius-md: 0.65rem;
+	--content-max: 42rem;
+	--wide-max: 64rem;
+	--header-height: 82px;
+	--footer-min-height: 8rem;
+}
+
 html {
-	background: #0b0c10;
+	background: var(--color-bg);
+	scroll-padding-top: calc(var(--header-height) + var(--space-md));
 }
 
 body {
-	font-family: 'Roboto', sans-serif;
-	color: #c5c6c7;
-	background: #0b0c10;
+	font-family: var(--font-body);
+	color: var(--color-text);
+	background: var(--color-bg);
 	padding: 0;
 	margin: 0;
-	line-height: 1.5em;
+	line-height: 1.6;
 	letter-spacing: 0.025em;
-}
-
-body a:hover 
-{
-	color: #45a29e;
+	text-rendering: optimizeLegibility;
 }
 
 body a {
-	color: #c5c6c7;
+	color: var(--color-text);
+	text-decoration-color: rgba(197, 198, 199, 0.45);
+	text-underline-offset: 0.18em;
+	transition: color 0.12s linear, text-decoration-color 0.12s linear;
 }
 
-body h1, h2 {
-	color: white;
-	font-weight: 200;
+body a:hover {
+	color: var(--color-accent-deep);
+	text-decoration-color: currentColor;
+}
+
+body :focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 3px;
+}
+
+h1,
+h2,
+h3 {
+	color: var(--color-text-strong);
+	font-weight: 300;
+	line-height: 1.15;
 	opacity: 0.9;
 }
 
+h1 {
+	font-family: var(--font-display);
+	font-size: clamp(2.5rem, 6vw, 4.8rem);
+	letter-spacing: -0.02em;
+}
+
+h2 {
+	font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+h3 {
+	font-size: 1.15rem;
+}
+
 .container {
-	position: relative;
 	min-height: 100vh;
-	background: #0b0c10;
+	background: var(--color-bg);
+	display: flex;
+	flex-direction: column;
 }
 
 .content {
-	padding-bottom: 150px;
+	flex: 1;
+	padding: var(--space-xl) 0 var(--space-2xl);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		scroll-behavior: auto !important;
+		transition-duration: 0.01ms !important;
+	}
 }

--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -1,9 +1,25 @@
 /* Footer styles */
 .footer {
-	position: absolute;
 	text-align: center;
-	background: #191b23;
-	height: 125px;
-	bottom: 0;
+	background: var(--color-surface-lift);
+	border-top: 1px solid var(--color-border-soft);
+	box-sizing: border-box;
+	color: var(--color-muted);
+	min-height: var(--footer-min-height);
+	padding: var(--space-lg) var(--space-md);
 	width: 100%;
+}
+
+.footer__title {
+	color: var(--color-text-strong);
+	font-family: var(--font-display);
+	font-size: 1.6rem;
+	letter-spacing: -0.01em;
+	line-height: 1.1;
+	margin: 0 0 var(--space-sm);
+	opacity: 0.9;
+}
+
+.footer p {
+	margin: 0;
 }

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -5,26 +5,27 @@
 	top: 0;
 	left: 0;
 	z-index: 1738;
-	background: #191b23;
-	box-shadow: 0px 1px 3px 0px black;
-	min-height: 82px;
-	padding: 0.85rem max(1rem, calc((100% - 960px) / 2));
+	background: rgba(25, 27, 35, 0.96);
+	border-bottom: 1px solid var(--color-border-soft);
+	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.75);
+	min-height: var(--header-height);
+	padding: 0.85rem max(var(--space-md), calc((100% - 960px) / 2));
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 1.5rem;
+	gap: var(--space-lg);
 	line-height: 1.2;
+	backdrop-filter: blur(12px);
 }
 
 .headerholder {
-	height: 82px;
+	height: var(--header-height);
 }
 
 .header a {
-	color: white;
+	color: var(--color-text-strong);
 	text-decoration: none;
-	transition: color 0.1s linear;	
 }
 
 .site-brand {
@@ -34,33 +35,44 @@
 	min-width: 0;
 }
 
+.site-brand__title {
+	color: var(--color-accent);
+	font-size: 1.45rem;
+	font-weight: 300;
+	letter-spacing: 0.01em;
+	white-space: nowrap;
+}
+
+.site-brand__title:hover {
+	color: var(--color-accent-deep);
+}
+
 .header nav {
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: 0.15em 0.35em;
+	gap: var(--space-xs);
 }
 
 .header nav a {
-	padding: 0.35em 0.55em;
+	border: 1px solid transparent;
+	border-radius: 999px;
+	color: var(--color-text);
+	font-size: 0.95rem;
+	padding: 0.35rem 0.65rem;
+	transition: background-color 0.12s linear, border-color 0.12s linear, color 0.12s linear;
 }
 
-.header h1 {
-	margin: 0;
+.header nav a:hover,
+.header nav a[aria-current="page"] {
+	background: var(--color-accent-wash);
+	border-color: var(--color-accent-ring);
+	color: var(--color-text-strong);
 }
 
-#headtitle {
-	font-size: 1.15em;
-}
-
-#headtitle a {
-	color: #66fcf1;
-	padding: 0;
-}
-
-#headtitle a:hover {
-	color: #45a29e;
+.header nav a:focus-visible {
+	outline-offset: 2px;
 }
 
 #headimg {

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -116,10 +116,6 @@ body {
 	gap: var(--space-xs);
 }
 
-.project-section__hint {
-	display: none;
-}
-
 .projects-page .project-section p {
 	margin: 0.25rem 0 1rem;
 	width: auto;

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -1,4 +1,17 @@
 /* Responsive/mobile styles */
+@media (max-width: 960px) {
+	.section,
+	.section.wide,
+	.projects {
+		width: min(46rem, calc(100% - 2rem));
+	}
+
+	.header {
+		padding-left: var(--space-md);
+		padding-right: var(--space-md);
+	}
+}
+
 @media (max-width: 640px) {
 body {
 	padding: 0;
@@ -7,13 +20,11 @@ body {
 }
 
 .container {
-	position: relative;
 	min-height: 100vh;
 }
 
 .content {
-	padding-bottom: 125px;
-	margin-top: 2vh;
+	padding: var(--space-lg) 0 var(--space-xl);
 }
 
 .header {
@@ -30,15 +41,16 @@ body {
 }
 
 .header a {
-	padding: 0.2em 0.4em;
+	padding: 0.2rem 0.4rem;
 }
 
 .header nav {
 	justify-content: center;
 }
 
-.header h1 {
-	margin: 0;
+.header nav a {
+	font-size: 0.9rem;
+	padding: 0.3rem 0.5rem;
 }
 
 #headimg {
@@ -46,22 +58,26 @@ body {
 	height: 42px;
 }
 
+.site-brand__title {
+	font-size: 1.25rem;
+}
+
 .site-brand {
 	justify-content: center;
 }
 
 .section {
-	width: 90%;
+	width: calc(100% - 2rem);
 }
 
 .section.wide {
-	width: 90%;
+	width: calc(100% - 2rem);
 }
 
 /* Spreadsheet iframes need larger width for readability */
 .section .spreadsheet-iframe {
-width: 625px;
-height: 600px;
+	width: 625px;
+	height: 600px;
 }
 
 .section.bg {
@@ -70,29 +86,38 @@ height: 600px;
 }
 
 .section h1 {
-	width: 95%;
+	width: 100%;
 }
 
 .section h2 {
-	margin-bottom: 5px;
+	margin-bottom: var(--space-sm);
 }
 
 .section p {
-	width: 90%;
-	margin: 0 auto;
+	width: 100%;
 }
 
 .projects {
-	width: 90%;
-	gap: 0.9em;
+	width: calc(100% - 2rem);
+	gap: var(--space-md);
 }
 
 .hero h1 {
-	font-size: 2.25em;
+	font-size: clamp(2.5rem, 14vw, 3.6rem);
 }
 
-.project {
-	flex: 1 1 100%;
+.project-card {
+	padding: var(--space-md);
+}
+
+.project-section__row {
+	align-items: flex-start;
+	flex-direction: column;
+	gap: var(--space-xs);
+}
+
+.project-section__hint {
+	display: none;
 }
 
 .projects-page .project-section p {
@@ -101,6 +126,6 @@ height: 600px;
 }
 
 .footer {
-	height: 100px;
+	min-height: 0;
 }
 }

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -94,14 +94,6 @@
 	margin: 0;
 }
 
-.project-section__count {
-	color: var(--color-accent-muted);
-	font-family: var(--font-mono);
-	font-size: 0.85rem;
-	font-weight: 400;
-	letter-spacing: 0.06em;
-}
-
 .project-section__hint {
 	color: var(--color-meta);
 	font-family: var(--font-mono);

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -1,35 +1,35 @@
 /* Section and project styles */
 .section {
 	position: relative;
-	padding-bottom: 1em;
-	width: 40%;
+	padding-bottom: var(--space-lg);
+	width: min(var(--content-max), calc(100% - 2rem));
 	margin: 0 auto;
 }
 
 .section.wide {
-	width: 56%;
+	width: min(56rem, calc(100% - 2rem));
 }
 
 .projects-page .section.wide,
 .projects-page .projects {
-	width: min(64rem, calc(100% - 2rem));
+	width: min(var(--wide-max), calc(100% - 2rem));
 }
 
 .hero h1 {
-	font-size: 3em;
-	line-height: 1.1em;
-	margin-bottom: 0.25em;
+	margin-bottom: var(--space-sm);
 }
 
 .lede {
-	font-size: 1.25em;
-	line-height: 1.6em;
+	color: var(--color-text-strong);
+	font-size: clamp(1.1rem, 2vw, 1.35rem);
+	line-height: 1.65;
 }
 
 .section img {
 	width: 90%;
 	display: block;
-	margin: 1em auto;
+	margin: var(--space-md) auto;
+	border-radius: var(--radius-sm);
 }
 
 .spreadsheet-iframe {
@@ -43,11 +43,11 @@
 }
 
 .section h2 {
-	margin: 0.5em 0;
+	margin: var(--space-sm) 0;
 }
 
 .section a {
-	transition: color 0.1s linear;
+	transition: color 0.12s linear, text-decoration-color 0.12s linear;
 }
 
 .section.social a {
@@ -55,11 +55,11 @@
 }
 
 #h2Link {
-	color: white;
+	color: var(--color-text-strong);
 }
 
 #h2Link:hover {
-	color: #45a29e;
+	color: var(--color-accent-deep);
 }
 
 #thumb {
@@ -67,118 +67,164 @@
 }
 
 .projects {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 1em;
-	width: 56%;
+	display: grid;
+	gap: var(--space-md);
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+	width: min(56rem, calc(100% - 2rem));
 	margin: 0 auto;
 }
 
 .project-section {
 	padding-bottom: 0;
-	margin-top: 1em;
+	margin-top: var(--space-xl);
 }
 
 .projects-page .projects + .project-section {
-	margin-top: 3rem;
+	margin-top: var(--space-2xl);
+}
+
+.project-section__row {
+	align-items: baseline;
+	display: flex;
+	gap: var(--space-md);
+	justify-content: space-between;
+}
+
+.project-section h2 {
+	margin: 0;
+}
+
+.project-section__count {
+	color: var(--color-accent-muted);
+	font-family: var(--font-mono);
+	font-size: 0.85rem;
+	font-weight: 400;
+	letter-spacing: 0.06em;
+}
+
+.project-section__hint {
+	color: var(--color-meta);
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
 }
 
 .projects-page .project-section p {
-	color: #adadad;
+	color: var(--color-muted);
 	margin: 0.25rem 0 1rem;
 	max-width: 42rem;
 	width: auto;
 }
 
-.project {
-	margin: 0;
-	padding: 1em;
-	border: 1px solid rgba(197, 198, 199, 0.16);
-	border-radius: 0.2em;
-	box-sizing: border-box;
-	flex: 1 1 16rem;
-	min-width: 0;
+.project-card {
 	background-color: rgba(20, 22, 29, 0.45);
-	text-decoration: none;
-	transition: background-color 0.25s, border-color 0.25s, transform 0.25s;
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	box-sizing: border-box;
+	color: var(--color-text);
 	display: flex;
 	flex-direction: column;
+	margin: 0;
+	min-width: 0;
+	padding: var(--space-lg);
 	position: relative;
+	text-decoration: none;
+	transition: background-color 0.25s, border-color 0.25s, transform 0.25s;
 }
 
-.project iframe {
-    width: 100%;
-    border-radius: 0.5em;
-    display: block;
-    box-sizing: border-box;
-    flex-grow: 1;
-    min-height: 200px; /* Fallback for browsers without aspect-ratio support */
+.project-card iframe {
+	width: 100%;
+	border-radius: var(--radius-sm);
+	display: block;
+	box-sizing: border-box;
+	aspect-ratio: 16 / 9;
+	min-height: 0;
 }
 
+.project-card__date,
 .post-date {
+	color: var(--color-meta);
 	font-style: italic;
 	margin: 0.5rem 0;
 }
 
+.project-card__meta,
 .project-meta {
-	color: #9bd9d6;
+	color: var(--color-accent-muted);
 	display: flex;
-	gap: 0.5em;
-	font-size: 0.9em;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	letter-spacing: 0.04em;
 	margin: 0;
+	text-transform: uppercase;
 }
 
-.project:hover {
+.project-card:hover {
 	background-color: rgba(20, 22, 29, 0.62);
 	border-color: rgba(101, 212, 205, 0.35);
 	transform: translateY(-2px);
 }
 
-.project:focus-visible {
-	outline: 2px solid #66fcf1;
+.project-card:focus-visible {
+	outline: 2px solid var(--color-accent);
 	outline-offset: 3px;
 }
 
-.project h2{
-	color:rgb(101, 212, 205);
+.project-card h2 {
+	color: var(--color-accent-mid);
+	font-family: var(--font-body);
+	font-size: clamp(1.35rem, 2vw, 1.75rem);
+	font-weight: 300;
 	margin-top: 0;
 	margin-bottom: 0.35rem;
 }
 
 .desc {
-	color: #adadad;
-	line-height: 1.55em;
+	color: var(--color-muted);
+	line-height: 1.55;
 	margin-bottom: 0;
 }
 
-.project .desc {
+.project-card .desc {
+	flex: 1;
 	margin-top: 0.75rem;
+}
+
+.project-card__cta {
+	color: var(--color-accent);
+	display: inline-flex;
+	font-size: 0.9rem;
+	margin-top: var(--space-md);
+	text-decoration: none;
 }
 
 /* External link indicator */
 .external-link-indicator {
-    position: absolute;
-    top: 0.5em;
-    right: 0.5em;
-    background-color: rgba(69, 162, 158, 0.2);
-    border-radius: 0.25em;
-    padding: 0.25em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1;
-    transition: all 0.25s;
+	position: absolute;
+	top: var(--space-sm);
+	right: var(--space-sm);
+	background-color: rgba(69, 162, 158, 0.2);
+	border-radius: var(--radius-sm);
+	padding: 0.25rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1;
+	transition: all 0.25s;
 }
 
 .external-link-indicator svg {
-    color: #45a29e;
-    width: 14px;
-    height: 14px;
+	color: var(--color-accent-deep);
+	width: 14px;
+	height: 14px;
 }
 
-.project:hover .external-link-indicator {
-    background-color: rgba(69, 162, 158, 0.3);
-    transform: scale(1.1);
+.project-card:hover .external-link-indicator {
+	background-color: rgba(69, 162, 158, 0.3);
+	transform: scale(1.1);
 }
 
 .external-link-indicator:hover {
@@ -186,6 +232,25 @@
 }
 
 video {
-    width: 100%;
-    border-radius: 0.5em;
+	width: 100%;
+	border-radius: var(--radius-sm);
+}
+
+.thumbnail,
+.project-iframe {
+	display: block;
+	margin-top: var(--space-md);
+	width: 100%;
+}
+
+img.thumbnail {
+	height: auto;
+	object-fit: cover;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.project-card:hover,
+	.project-card:hover .external-link-indicator {
+		transform: none;
+	}
 }

--- a/projects.html
+++ b/projects.html
@@ -7,26 +7,52 @@ permalink: /projects/
 {% assign current_project_titles = "Copilot Bridge|Mineless|Circles" | split: "|" %}
 {% assign selected_project_titles = "Windows App Restarter|YouTube Summarizer with Gemini|The Mighty Architectury|GluChart" | split: "|" %}
 {% assign hidden_project_titles = "Career Expo Project" | split: "|" %}
-{% assign current_project_count = 0 %}
+{% assign current_start_year = "" %}
+{% assign current_end_year = "" %}
 {% for project_title in current_project_titles %}
   {% assign project = site.posts | where: "title", project_title | first %}
   {% if project %}
-    {% assign current_project_count = current_project_count | plus: 1 %}
+    {% assign project_year = project.start_date | default: project.date | date: "%Y" %}
+    {% if current_start_year == "" or project_year < current_start_year %}
+      {% assign current_start_year = project_year %}
+    {% endif %}
+    {% if current_end_year == "" or project_year > current_end_year %}
+      {% assign current_end_year = project_year %}
+    {% endif %}
   {% endif %}
 {% endfor %}
-{% assign selected_project_count = 0 %}
+{% capture current_year_hint %}{% if current_start_year == current_end_year %}{{ current_start_year }}{% else %}{{ current_start_year }}-{{ current_end_year }}{% endif %}{% endcapture %}
+
+{% assign selected_start_year = "" %}
+{% assign selected_end_year = "" %}
 {% for project_title in selected_project_titles %}
   {% assign project = site.posts | where: "title", project_title | first %}
   {% if project %}
-    {% assign selected_project_count = selected_project_count | plus: 1 %}
+    {% assign project_year = project.start_date | default: project.date | date: "%Y" %}
+    {% if selected_start_year == "" or project_year < selected_start_year %}
+      {% assign selected_start_year = project_year %}
+    {% endif %}
+    {% if selected_end_year == "" or project_year > selected_end_year %}
+      {% assign selected_end_year = project_year %}
+    {% endif %}
   {% endif %}
 {% endfor %}
-{% assign archive_project_count = 0 %}
+{% capture selected_year_hint %}{% if selected_start_year == selected_end_year %}{{ selected_start_year }}{% else %}{{ selected_start_year }}-{{ selected_end_year }}{% endif %}{% endcapture %}
+
+{% assign archive_start_year = "" %}
+{% assign archive_end_year = "" %}
 {% for post in site.posts %}
   {% unless current_project_titles contains post.title or selected_project_titles contains post.title or hidden_project_titles contains post.title %}
-    {% assign archive_project_count = archive_project_count | plus: 1 %}
+    {% assign project_year = post.start_date | default: post.date | date: "%Y" %}
+    {% if archive_start_year == "" or project_year < archive_start_year %}
+      {% assign archive_start_year = project_year %}
+    {% endif %}
+    {% if archive_end_year == "" or project_year > archive_end_year %}
+      {% assign archive_end_year = project_year %}
+    {% endif %}
   {% endunless %}
 {% endfor %}
+{% capture archive_year_hint %}{% if archive_start_year == archive_end_year %}{{ archive_start_year }}{% else %}{{ archive_start_year }}-{{ archive_end_year }}{% endif %}{% endcapture %}
 
 <div class="content projects-page">
   <div class="section wide">
@@ -35,8 +61,8 @@ permalink: /projects/
 
   <div class="section wide project-section">
     <div class="project-section__row">
-      <h2>Current <span class="project-section__count">/ {% if current_project_count < 10 %}0{% endif %}{{ current_project_count }}</span></h2>
-      <span class="project-section__hint">Active work</span>
+      <h2>Current</h2>
+      <span class="project-section__hint">{{ current_year_hint }}</span>
     </div>
     <p>Things I am actively building, shaping, using, or deciding the future of.</p>
   </div>
@@ -51,8 +77,8 @@ permalink: /projects/
 
   <div class="section wide project-section">
     <div class="project-section__row">
-      <h2>Selected Work <span class="project-section__count">/ {% if selected_project_count < 10 %}0{% endif %}{{ selected_project_count }}</span></h2>
-      <span class="project-section__hint">Representative projects</span>
+      <h2>Selected Work</h2>
+      <span class="project-section__hint">{{ selected_year_hint }}</span>
     </div>
     <p>Finished or stable projects that still feel representative of what I like to make.</p>
   </div>
@@ -67,8 +93,8 @@ permalink: /projects/
 
   <div class="section wide project-section">
     <div class="project-section__row">
-      <h2>Archive <span class="project-section__count">/ {% if archive_project_count < 10 %}0{% endif %}{{ archive_project_count }}</span></h2>
-      <span class="project-section__hint">Older things</span>
+      <h2>Archive</h2>
+      <span class="project-section__hint">{{ archive_year_hint }}</span>
     </div>
     <p>Older, smaller, or more nostalgic things I still want to keep around.</p>
   </div>

--- a/projects.html
+++ b/projects.html
@@ -7,6 +7,26 @@ permalink: /projects/
 {% assign current_project_titles = "Copilot Bridge|Mineless|Circles" | split: "|" %}
 {% assign selected_project_titles = "Windows App Restarter|YouTube Summarizer with Gemini|The Mighty Architectury|GluChart" | split: "|" %}
 {% assign hidden_project_titles = "Career Expo Project" | split: "|" %}
+{% assign current_project_count = 0 %}
+{% for project_title in current_project_titles %}
+  {% assign project = site.posts | where: "title", project_title | first %}
+  {% if project %}
+    {% assign current_project_count = current_project_count | plus: 1 %}
+  {% endif %}
+{% endfor %}
+{% assign selected_project_count = 0 %}
+{% for project_title in selected_project_titles %}
+  {% assign project = site.posts | where: "title", project_title | first %}
+  {% if project %}
+    {% assign selected_project_count = selected_project_count | plus: 1 %}
+  {% endif %}
+{% endfor %}
+{% assign archive_project_count = 0 %}
+{% for post in site.posts %}
+  {% unless current_project_titles contains post.title or selected_project_titles contains post.title or hidden_project_titles contains post.title %}
+    {% assign archive_project_count = archive_project_count | plus: 1 %}
+  {% endunless %}
+{% endfor %}
 
 <div class="content projects-page">
   <div class="section wide">
@@ -14,7 +34,10 @@ permalink: /projects/
   </div>
 
   <div class="section wide project-section">
-    <h2>Current</h2>
+    <div class="project-section__row">
+      <h2>Current <span class="project-section__count">/ {% if current_project_count < 10 %}0{% endif %}{{ current_project_count }}</span></h2>
+      <span class="project-section__hint">Active work</span>
+    </div>
     <p>Things I am actively building, shaping, using, or deciding the future of.</p>
   </div>
   <div class="projects">
@@ -27,7 +50,10 @@ permalink: /projects/
   </div>
 
   <div class="section wide project-section">
-    <h2>Selected Work</h2>
+    <div class="project-section__row">
+      <h2>Selected Work <span class="project-section__count">/ {% if selected_project_count < 10 %}0{% endif %}{{ selected_project_count }}</span></h2>
+      <span class="project-section__hint">Representative projects</span>
+    </div>
     <p>Finished or stable projects that still feel representative of what I like to make.</p>
   </div>
   <div class="projects">
@@ -40,7 +66,10 @@ permalink: /projects/
   </div>
 
   <div class="section wide project-section">
-    <h2>Archive</h2>
+    <div class="project-section__row">
+      <h2>Archive <span class="project-section__count">/ {% if archive_project_count < 10 %}0{% endif %}{{ archive_project_count }}</span></h2>
+      <span class="project-section__hint">Older things</span>
+    </div>
     <p>Older, smaller, or more nostalgic things I still want to keep around.</p>
   </div>
   <div class="projects">


### PR DESCRIPTION
## Summary
- add shared visual tokens, type rhythm, focus styling, and reduced-motion guardrails
- polish the global header/footer shell with active nav states and shared sizing
- refresh reusable project cards while preserving the existing content structure
- show build-time Projects section date ranges derived from each section's projects
- tune tablet/mobile widths, card spacing, and project section behavior

## Validation
- Built with Docker Ruby: `bundle exec jekyll build`
- Checked generated local links/assets resolve under `_site`
- Inspected built Projects page at desktop and mobile widths after the date-range hint adjustment