### PR TITLE
Add phase 2 page refresh

### DIFF
--- a/_data/project_groups.yml
+++ b/_data/project_groups.yml
@@ -1,0 +1,13 @@
+current:
+  - Copilot Bridge
+  - Mineless
+  - Circles
+
+selected:
+  - Windows App Restarter
+  - YouTube Summarizer with Gemini
+  - The Mighty Architectury
+  - GluChart
+
+hidden:
+  - Career Expo Project

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,8 +2,29 @@
 layout: default
 ---
 
-<div class="content">
-  <div class="section">
-    {{ content }}
-  </div>
+<div class="content project-detail-page">
+  <article class="section project-detail">
+    {% if page.status or page.project_type or page.start_date or page.project_url or page.source_url or page.external_url %}
+    <div class="project-detail__meta" aria-label="Project summary">
+      {% if page.status %}<span>{{ page.status }}</span>{% endif %}
+      {% if page.project_type %}<span>{{ page.project_type }}</span>{% endif %}
+      {% if page.start_date %}
+        <span>
+          {{ page.start_date | date: "%B %Y" }}
+          {% if page.end_date %}
+            -
+            {% if page.end_date == "Present" %}Present{% else %}{{ page.end_date | date: "%B %Y" }}{% endif %}
+          {% endif %}
+        </span>
+      {% endif %}
+      {% if page.project_url %}<a href="{{ page.project_url }}" target="_blank" rel="noreferrer noopener">Open project</a>{% endif %}
+      {% if page.source_url %}<a href="{{ page.source_url }}" target="_blank" rel="noreferrer noopener">Source</a>{% endif %}
+      {% if page.external_url %}<a href="{{ page.external_url }}" target="_blank" rel="noreferrer noopener">External link</a>{% endif %}
+    </div>
+    {% endif %}
+
+    <div class="project-detail__body">
+      {{ content }}
+    </div>
+  </article>
 </div>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -99,6 +99,16 @@ h3 {
 	padding: var(--space-xl) 0 var(--space-2xl);
 }
 
+.visually-hidden {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	*,
 	*::before,

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -110,6 +110,33 @@ body {
 	padding: var(--space-md);
 }
 
+.section-grid {
+	grid-template-columns: 1fr;
+	margin-top: var(--space-xl);
+}
+
+.resume-card {
+	align-items: flex-start;
+	flex-direction: column;
+}
+
+.resume-card__actions {
+	width: 100%;
+}
+
+.resume-card__actions .button-link {
+	justify-content: center;
+}
+
+.social-row {
+	align-items: flex-start;
+	padding: var(--space-md);
+}
+
+.social-row__arrow {
+	font-size: 1.1rem;
+}
+
 .project-section__row {
 	align-items: flex-start;
 	flex-direction: column;

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -110,9 +110,23 @@ body {
 	padding: var(--space-md);
 }
 
-.section-grid {
+.home-hero {
+	padding-top: var(--space-xl);
+}
+
+.home-hero h1 {
+	font-size: clamp(3.5rem, 17vw, 5.5rem);
+}
+
+.home-section__head {
+	align-items: flex-start;
+	flex-direction: column;
+	gap: var(--space-xs);
+	margin-bottom: var(--space-lg);
+}
+
+.interest-grid {
 	grid-template-columns: 1fr;
-	margin-top: var(--space-xl);
 }
 
 .resume-card {

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -169,6 +169,13 @@ body {
 	padding: var(--space-md);
 }
 
+.social-row__icon {
+	flex-basis: 2.4rem;
+	font-size: 1.05rem;
+	height: 2.4rem;
+	width: 2.4rem;
+}
+
 .social-row__arrow {
 	font-size: 1.1rem;
 }

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -125,6 +125,24 @@ body {
 	margin-bottom: var(--space-lg);
 }
 
+.page-hero h1 {
+	font-size: clamp(3rem, 16vw, 5rem);
+}
+
+.section-head {
+	margin-bottom: var(--space-lg);
+}
+
+.section-head__row {
+	align-items: flex-start;
+	flex-direction: column;
+	gap: var(--space-xs);
+}
+
+.jump-nav {
+	gap: var(--space-xs);
+}
+
 .interest-grid {
 	grid-template-columns: 1fr;
 }
@@ -142,6 +160,10 @@ body {
 	justify-content: center;
 }
 
+.preview-grid {
+	grid-template-columns: 1fr;
+}
+
 .social-row {
 	align-items: flex-start;
 	padding: var(--space-md);
@@ -149,17 +171,6 @@ body {
 
 .social-row__arrow {
 	font-size: 1.1rem;
-}
-
-.project-section__row {
-	align-items: flex-start;
-	flex-direction: column;
-	gap: var(--space-xs);
-}
-
-.projects-page .project-section p {
-	margin: 0.25rem 0 1rem;
-	width: auto;
 }
 
 .footer {

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -114,6 +114,85 @@
 	color: var(--color-text-strong);
 }
 
+.page-hero {
+	padding-bottom: clamp(3rem, 8vh, 5rem);
+	padding-top: clamp(2rem, 6vh, 4rem);
+}
+
+.page-hero h1 {
+	font-size: clamp(3.25rem, 8vw, 6.5rem);
+	line-height: 0.98;
+	margin: 0 0 var(--space-md);
+}
+
+.page-hero .lede {
+	color: var(--color-text);
+	max-width: 42rem;
+}
+
+.page-section {
+	border-top: 1px solid var(--color-border-soft);
+	padding-bottom: clamp(2.5rem, 7vh, 4.5rem);
+	padding-top: clamp(2.5rem, 7vh, 4.5rem);
+}
+
+.section-head {
+	display: grid;
+	gap: var(--space-xs);
+	margin-bottom: var(--space-xl);
+}
+
+.section-head__row {
+	align-items: baseline;
+	display: flex;
+	gap: var(--space-lg);
+	justify-content: space-between;
+}
+
+.section-head__title {
+	font-family: var(--font-display);
+	margin: 0;
+}
+
+.section-head__hint {
+	color: var(--color-meta);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.section-head p {
+	color: var(--color-muted);
+	margin: 0;
+	max-width: 42rem;
+}
+
+.jump-nav {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+	margin-top: var(--space-lg);
+}
+
+.jump-nav a {
+	border: 1px solid var(--color-border);
+	border-radius: 999px;
+	color: var(--color-text);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.05em;
+	padding: 0.45rem 0.7rem;
+	text-decoration: none;
+	text-transform: uppercase;
+}
+
+.jump-nav a:hover {
+	background: var(--color-accent-wash);
+	border-color: var(--color-accent-ring);
+	color: var(--color-accent);
+}
+
 .resume-card,
 .nudge-card {
 	background: rgba(20, 22, 29, 0.45);
@@ -124,6 +203,7 @@
 }
 
 .resume-card h2,
+.resume-card h3,
 .nudge-card h2 {
 	margin-top: 0;
 }
@@ -257,34 +337,12 @@
 	margin-top: var(--space-xl);
 }
 
+.projects-page .project-section {
+	margin-top: 0;
+}
+
 .projects-page .projects + .project-section {
 	margin-top: var(--space-2xl);
-}
-
-.project-section__row {
-	align-items: baseline;
-	display: flex;
-	gap: var(--space-md);
-	justify-content: space-between;
-}
-
-.project-section h2 {
-	margin: 0;
-}
-
-.project-section__hint {
-	color: var(--color-meta);
-	font-family: var(--font-mono);
-	font-size: 0.8rem;
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-}
-
-.projects-page .project-section p {
-	color: var(--color-muted);
-	margin: 0.25rem 0 1rem;
-	max-width: 42rem;
-	width: auto;
 }
 
 .project-card {
@@ -418,10 +476,6 @@ img.thumbnail {
 	object-fit: cover;
 }
 
-.page-hero {
-	padding-bottom: var(--space-xl);
-}
-
 .resume-card {
 	align-items: center;
 	display: flex;
@@ -445,8 +499,50 @@ img.thumbnail {
 	gap: var(--space-sm);
 }
 
+.preview-grid {
+	display: grid;
+	gap: var(--space-md);
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.preview {
+	background: rgba(20, 22, 29, 0.45);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	display: grid;
+	gap: var(--space-xs);
+	padding: var(--space-lg);
+}
+
+.preview__num {
+	color: var(--color-accent-muted);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.08em;
+}
+
+.preview__title {
+	color: var(--color-text-strong);
+	font-family: var(--font-display);
+	font-size: 1.2rem;
+}
+
+.preview__detail {
+	color: var(--color-muted);
+	line-height: 1.55;
+}
+
 .nudge-card {
-	margin-top: var(--space-lg);
+	display: grid;
+	gap: var(--space-sm);
+}
+
+.nudge-card__label {
+	color: var(--color-accent-muted);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
 }
 
 .project-detail {

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -20,7 +20,8 @@
 }
 
 .home-hero {
-	padding-bottom: var(--space-xl);
+	padding-bottom: clamp(4rem, 9vh, 7rem);
+	padding-top: clamp(2rem, 8vh, 5rem);
 }
 
 .home-hero h1 em,
@@ -38,36 +39,48 @@
 	text-transform: uppercase;
 }
 
+.home-hero h1 {
+	font-size: clamp(3.5rem, 11vw, 8.25rem);
+	line-height: 0.96;
+	letter-spacing: -0.025em;
+	margin-bottom: var(--space-lg);
+	max-width: 12ch;
+}
+
 .lede {
 	color: var(--color-text-strong);
 	font-size: clamp(1.1rem, 2vw, 1.35rem);
 	line-height: 1.65;
 }
 
+.home-hero .lede {
+	color: var(--color-text);
+	font-size: clamp(1.1rem, 1.6vw, 1.32rem);
+	line-height: 1.55;
+	max-width: 38rem;
+}
+
 .meta-strip {
-	border: 1px solid var(--color-border);
-	border-radius: var(--radius-md);
+	align-items: center;
+	color: var(--color-meta);
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--space-sm);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	gap: 0.25rem 0.75rem;
+	letter-spacing: 0.05em;
 	margin: var(--space-lg) 0 0;
-	padding: var(--space-sm);
 }
 
 .meta-strip span {
-	background: var(--color-accent-wash);
-	border: 1px solid var(--color-border-soft);
-	border-radius: 999px;
-	color: var(--color-text-strong);
-	font-size: 0.9rem;
-	padding: 0.35rem 0.65rem;
+	display: inline-flex;
 }
 
-.hero-actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: var(--space-sm);
-	margin-top: var(--space-lg);
+.meta-strip .sep {
+	background: var(--color-border);
+	border-radius: 50%;
+	height: 4px;
+	width: 4px;
 }
 
 .button-link {
@@ -101,19 +114,6 @@
 	color: var(--color-text-strong);
 }
 
-.home-projects {
-	width: min(var(--wide-max), calc(100% - 2rem));
-}
-
-.section-grid {
-	display: grid;
-	gap: var(--space-md);
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	margin: var(--space-2xl) auto 0;
-	width: min(var(--wide-max), calc(100% - 2rem));
-}
-
-.info-card,
 .resume-card,
 .nudge-card {
 	background: rgba(20, 22, 29, 0.45);
@@ -123,32 +123,84 @@
 	padding: var(--space-lg);
 }
 
-.info-card h2,
 .resume-card h2,
 .nudge-card h2 {
 	margin-top: 0;
 }
 
-.info-card p:last-child,
 .resume-card p:last-child,
 .nudge-card p:last-child {
 	margin-bottom: 0;
 }
 
-.tag-list {
-	display: flex;
-	flex-wrap: wrap;
-	gap: var(--space-sm);
-	list-style: none;
-	margin: var(--space-md) 0 0;
-	padding: 0;
+.home-section {
+	border-top: 1px solid var(--color-border-soft);
+	padding-bottom: clamp(2.5rem, 8vh, 5rem);
+	padding-top: clamp(2.5rem, 8vh, 5rem);
 }
 
-.tag-list li {
-	border: 1px solid var(--color-border);
-	border-radius: 999px;
+.home-section__head {
+	align-items: baseline;
+	display: flex;
+	gap: var(--space-lg);
+	justify-content: space-between;
+	margin-bottom: var(--space-xl);
+}
+
+.home-section__head h2 {
+	font-family: var(--font-display);
+	margin: 0;
+}
+
+.home-section__head span {
+	color: var(--color-meta);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.home-copy {
+	max-width: 42rem;
+}
+
+.home-copy p {
+	margin: 0;
+}
+
+.home-copy p + p {
+	margin-top: var(--space-md);
+}
+
+.interest-grid {
+	border: 1px solid var(--color-border-soft);
+	border-radius: var(--radius-md);
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+	overflow: hidden;
+}
+
+.interest {
+	background: rgba(20, 22, 29, 0.4);
+	border: 1px solid var(--color-border-soft);
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
+	margin: -1px 0 0 -1px;
+	padding: 1.1rem 1.2rem;
+}
+
+.interest__name {
+	color: var(--color-text-strong);
+	font-family: var(--font-display);
+	font-size: 1.05rem;
+}
+
+.interest__detail {
 	color: var(--color-muted);
-	padding: 0.35rem 0.65rem;
+	font-family: var(--font-mono);
+	font-size: 0.72rem;
+	letter-spacing: 0.06em;
 }
 
 .section img {

--- a/assets/css/section.css
+++ b/assets/css/section.css
@@ -19,10 +19,136 @@
 	margin-bottom: var(--space-sm);
 }
 
+.home-hero {
+	padding-bottom: var(--space-xl);
+}
+
+.home-hero h1 em,
+.page-hero h1 em {
+	color: var(--color-accent);
+	font-style: italic;
+}
+
+.eyebrow {
+	color: var(--color-accent-muted);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.12em;
+	margin: 0 0 var(--space-sm);
+	text-transform: uppercase;
+}
+
 .lede {
 	color: var(--color-text-strong);
 	font-size: clamp(1.1rem, 2vw, 1.35rem);
 	line-height: 1.65;
+}
+
+.meta-strip {
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+	margin: var(--space-lg) 0 0;
+	padding: var(--space-sm);
+}
+
+.meta-strip span {
+	background: var(--color-accent-wash);
+	border: 1px solid var(--color-border-soft);
+	border-radius: 999px;
+	color: var(--color-text-strong);
+	font-size: 0.9rem;
+	padding: 0.35rem 0.65rem;
+}
+
+.hero-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+	margin-top: var(--space-lg);
+}
+
+.button-link {
+	align-items: center;
+	background: var(--color-accent);
+	border: 1px solid var(--color-accent);
+	border-radius: 999px;
+	color: var(--color-bg);
+	display: inline-flex;
+	font-weight: 400;
+	line-height: 1;
+	padding: 0.75rem 1rem;
+	text-decoration: none;
+}
+
+.button-link:hover {
+	background: var(--color-accent-deep);
+	border-color: var(--color-accent-deep);
+	color: var(--color-bg);
+}
+
+.button-link--secondary {
+	background: transparent;
+	border-color: var(--color-border);
+	color: var(--color-text-strong);
+}
+
+.button-link--secondary:hover {
+	background: var(--color-accent-wash);
+	border-color: var(--color-accent-ring);
+	color: var(--color-text-strong);
+}
+
+.home-projects {
+	width: min(var(--wide-max), calc(100% - 2rem));
+}
+
+.section-grid {
+	display: grid;
+	gap: var(--space-md);
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	margin: var(--space-2xl) auto 0;
+	width: min(var(--wide-max), calc(100% - 2rem));
+}
+
+.info-card,
+.resume-card,
+.nudge-card {
+	background: rgba(20, 22, 29, 0.45);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	box-sizing: border-box;
+	padding: var(--space-lg);
+}
+
+.info-card h2,
+.resume-card h2,
+.nudge-card h2 {
+	margin-top: 0;
+}
+
+.info-card p:last-child,
+.resume-card p:last-child,
+.nudge-card p:last-child {
+	margin-bottom: 0;
+}
+
+.tag-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-sm);
+	list-style: none;
+	margin: var(--space-md) 0 0;
+	padding: 0;
+}
+
+.tag-list li {
+	border: 1px solid var(--color-border);
+	border-radius: 999px;
+	color: var(--color-muted);
+	padding: 0.35rem 0.65rem;
 }
 
 .section img {
@@ -238,6 +364,102 @@ video {
 img.thumbnail {
 	height: auto;
 	object-fit: cover;
+}
+
+.page-hero {
+	padding-bottom: var(--space-xl);
+}
+
+.resume-card {
+	align-items: center;
+	display: flex;
+	gap: var(--space-lg);
+	justify-content: space-between;
+}
+
+.resume-card__kicker {
+	color: var(--color-accent-muted);
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.12em;
+	margin: 0 0 var(--space-xs);
+	text-transform: uppercase;
+}
+
+.resume-card__actions {
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
+	gap: var(--space-sm);
+}
+
+.nudge-card {
+	margin-top: var(--space-lg);
+}
+
+.project-detail {
+	width: min(46rem, calc(100% - 2rem));
+}
+
+.project-detail__meta {
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	color: var(--color-meta);
+	display: flex;
+	flex-wrap: wrap;
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	gap: var(--space-sm);
+	letter-spacing: 0.04em;
+	margin-bottom: var(--space-xl);
+	padding: var(--space-sm);
+	text-transform: uppercase;
+}
+
+.project-detail__meta span,
+.project-detail__meta a {
+	background: var(--color-accent-wash);
+	border-radius: 999px;
+	padding: 0.35rem 0.65rem;
+	text-decoration: none;
+}
+
+.project-detail__meta a {
+	color: var(--color-accent);
+}
+
+.project-detail__body h1 {
+	margin-top: 0;
+}
+
+.project-detail__body h2 {
+	margin-top: var(--space-xl);
+}
+
+.project-detail__body h3 {
+	color: var(--color-accent-muted);
+	margin-bottom: 0.25rem;
+}
+
+.project-detail__body ul,
+.project-detail__body ol {
+	padding-left: 1.3rem;
+}
+
+.project-detail__body li + li {
+	margin-top: 0.35rem;
+}
+
+.project-detail__body img,
+.project-detail__body video,
+.project-detail__body iframe {
+	border-radius: var(--radius-md);
+	box-sizing: border-box;
+	max-width: 100%;
+}
+
+.project-detail__body iframe {
+	width: 100%;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/social.css
+++ b/assets/css/social.css
@@ -1,10 +1,66 @@
-/* Social section styles */
-.section.social {
-	text-align: center;
+.social-list {
+	display: grid;
+	gap: var(--space-md);
 }
 
-.social a {
-	font-size: 2em;
-	display: block;
-	margin: 1em 0;
+.social-row {
+	align-items: center;
+	background: rgba(20, 22, 29, 0.45);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	box-sizing: border-box;
+	color: var(--color-text);
+	display: flex;
+	gap: var(--space-md);
+	justify-content: space-between;
+	padding: var(--space-lg);
+	text-decoration: none;
+	transition: background-color 0.25s, border-color 0.25s, transform 0.25s;
+}
+
+.social-row:hover {
+	background: rgba(20, 22, 29, 0.62);
+	border-color: rgba(101, 212, 205, 0.35);
+	color: var(--color-text);
+	transform: translateY(-2px);
+}
+
+.social-row:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 3px;
+}
+
+.social-row__main,
+.social-row__top {
+	display: grid;
+	gap: var(--space-xs);
+}
+
+.social-row__name {
+	color: var(--color-accent-mid);
+	font-size: 1.35rem;
+	line-height: 1.15;
+}
+
+.social-row__handle {
+	color: var(--color-meta);
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	letter-spacing: 0.04em;
+}
+
+.social-row__note {
+	color: var(--color-muted);
+	line-height: 1.55;
+}
+
+.social-row__arrow {
+	color: var(--color-accent);
+	font-size: 1.4rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.social-row:hover {
+		transform: none;
+	}
 }

--- a/assets/css/social.css
+++ b/assets/css/social.css
@@ -30,10 +30,34 @@
 	outline-offset: 3px;
 }
 
+.social-row__icon {
+	align-items: center;
+	background: var(--color-accent-wash);
+	border: 1px solid var(--color-border-soft);
+	border-radius: 999px;
+	color: var(--color-accent);
+	display: inline-flex;
+	flex: 0 0 2.75rem;
+	font-size: 1.25rem;
+	height: 2.75rem;
+	justify-content: center;
+	width: 2.75rem;
+}
+
+.social-row:hover .social-row__icon {
+	border-color: var(--color-accent-ring);
+	color: var(--color-text-strong);
+}
+
 .social-row__main,
 .social-row__top {
 	display: grid;
 	gap: var(--space-xs);
+}
+
+.social-row__main {
+	flex: 1;
+	min-width: 0;
 }
 
 .social-row__name {

--- a/assets/css/social.css
+++ b/assets/css/social.css
@@ -59,6 +59,29 @@
 	font-size: 1.4rem;
 }
 
+.aside-note {
+	border: 1px solid var(--color-border-soft);
+	border-radius: var(--radius-md);
+	color: var(--color-muted);
+	margin-top: var(--space-xl);
+	padding: var(--space-lg);
+}
+
+.aside-note__label {
+	color: var(--color-accent-muted);
+	display: block;
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.12em;
+	margin-bottom: var(--space-xs);
+	text-transform: uppercase;
+}
+
+.aside-note p {
+	margin: 0;
+	max-width: 42rem;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.social-row:hover {
 		transform: none;

--- a/index.html
+++ b/index.html
@@ -4,45 +4,27 @@ title: Home
 ---
 <div class="content home-page">
   <div class="section wide hero home-hero">
-    <p class="eyebrow">Personal site / project archive</p>
+    <p class="eyebrow">Online / timmie / tiimmie / timstewartj</p>
     <h1>Tim <em>Stewart</em>.</h1>
     <p class="lede">
-      My name is Tim. Online I usually go by timmie, tiimmie, or timstewartj.
-    </p>
-    <p>
-      I'm a software engineer, and I like coding, video games, mechanical keyboards,
+      Software engineer. I like coding, video games, mechanical keyboards,
       PC building, journaling, and making small tools when I wish something existed.
     </p>
     <div class="meta-strip" aria-label="At a glance">
       <span>Software engineer</span>
-      <span>Personal tools</span>
-      <span>Games and journaling</span>
+      <span class="sep" aria-hidden="true"></span>
+      <span>Personal projects</span>
+      <span class="sep" aria-hidden="true"></span>
+      <span>Small useful tools</span>
     </div>
-    <p class="hero-actions">
-      <a class="button-link" href="{{ "/projects" | relative_url }}">See projects</a>
-      <a class="button-link button-link--secondary" href="{{ "/resume" | relative_url }}">View resume</a>
-    </p>
   </div>
 
-  <div class="section wide project-section">
-    <div class="project-section__row">
-      <h2>Currently building</h2>
-      <span class="project-section__hint">See all on Projects</span>
-    </div>
-    <p>Things I am actively building, shaping, using, or deciding the future of.</p>
-  </div>
-  <div class="projects home-projects">
-    {% for project_title in site.data.project_groups.current %}
-      {% assign project = site.posts | where: "title", project_title | first %}
-      {% if project %}
-        {% include project-card.html project=project %}
-      {% endif %}
-    {% endfor %}
-  </div>
-
-  <div class="section-grid">
-    <section class="info-card">
+  <section class="section wide home-section" aria-labelledby="about-title">
+    <header class="home-section__head">
       <h2>About the site</h2>
+      <span>Home base</span>
+    </header>
+    <div class="home-copy">
       <p>
         You can find things that I'm working on, things that I've done, and my resume here.
         I try to keep it up to date, but it may still be a bit behind what I'm actually up to.
@@ -50,18 +32,42 @@ title: Home
       <p>
         While it may not seem like much, it's enough for me to call home :)
       </p>
-    </section>
+      <p>
+        A less formal view of my work lives on the <a href="{{ "/projects" | relative_url }}">Projects page</a>;
+        a more formal one is on the <a href="{{ "/resume" | relative_url }}">Resume</a>.
+      </p>
+    </div>
+  </section>
 
-    <section class="info-card">
+  <section class="section wide home-section" aria-labelledby="interests-title">
+    <header class="home-section__head">
       <h2>What I keep coming back to</h2>
-      <ul class="tag-list">
-        <li>Coding</li>
-        <li>Video games</li>
-        <li>Mechanical keyboards</li>
-        <li>PC building</li>
-        <li>Journaling</li>
-        <li>Small tools</li>
-      </ul>
-    </section>
-  </div>
+    </header>
+    <div class="interest-grid" role="list">
+      <div class="interest" role="listitem">
+        <span class="interest__name">Coding</span>
+        <span class="interest__detail">Small useful tools</span>
+      </div>
+      <div class="interest" role="listitem">
+        <span class="interest__name">Games</span>
+        <span class="interest__detail">Playing and making</span>
+      </div>
+      <div class="interest" role="listitem">
+        <span class="interest__name">Mechanical keyboards</span>
+        <span class="interest__detail">Builds, switches, layouts</span>
+      </div>
+      <div class="interest" role="listitem">
+        <span class="interest__name">PC building</span>
+        <span class="interest__detail">Towers, cables, quiet fans</span>
+      </div>
+      <div class="interest" role="listitem">
+        <span class="interest__name">Journaling</span>
+        <span class="interest__detail">Solo and in small circles</span>
+      </div>
+      <div class="interest" role="listitem">
+        <span class="interest__name">Personal projects</span>
+        <span class="interest__detail">Wishing things existed</span>
+      </div>
+    </div>
+  </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -2,29 +2,66 @@
 layout: default
 title: Home
 ---
-<div class="content">
-    <div class="section wide hero">
-        <h1>Welcome</h1>
-        <p class="lede">
-            My name is Tim. Online I usually go by timmie, tiimmie, or timstewartj.
-        </p>
-        <p>
-            I'm a software engineer, and I like coding, video games, mechanical keyboards,
-            PC building, journaling, and making small tools when I wish something existed.
-        </p>
-        <p>
-            I keep projects I've made on the <a href="{{ "/projects" | relative_url }}">Projects</a> page.
-        </p>
+<div class="content home-page">
+  <div class="section wide hero home-hero">
+    <p class="eyebrow">Personal site / project archive</p>
+    <h1>Tim <em>Stewart</em>.</h1>
+    <p class="lede">
+      My name is Tim. Online I usually go by timmie, tiimmie, or timstewartj.
+    </p>
+    <p>
+      I'm a software engineer, and I like coding, video games, mechanical keyboards,
+      PC building, journaling, and making small tools when I wish something existed.
+    </p>
+    <div class="meta-strip" aria-label="At a glance">
+      <span>Software engineer</span>
+      <span>Personal tools</span>
+      <span>Games and journaling</span>
     </div>
+    <p class="hero-actions">
+      <a class="button-link" href="{{ "/projects" | relative_url }}">See projects</a>
+      <a class="button-link button-link--secondary" href="{{ "/resume" | relative_url }}">View resume</a>
+    </p>
+  </div>
 
-    <div class="section wide">
-        <h2>About the site</h2>
-        <p>
-            You can find things that I'm working on, things that I've done, and my resume here.
-            I try to keep it up to date, but it may still be a bit behind what I'm actually up to.
-        </p>
-        <p>
-            While it may not seem like much, it's enough for me to call home :)
-        </p>
+  <div class="section wide project-section">
+    <div class="project-section__row">
+      <h2>Currently building</h2>
+      <span class="project-section__hint">See all on Projects</span>
     </div>
+    <p>Things I am actively building, shaping, using, or deciding the future of.</p>
+  </div>
+  <div class="projects home-projects">
+    {% for project_title in site.data.project_groups.current %}
+      {% assign project = site.posts | where: "title", project_title | first %}
+      {% if project %}
+        {% include project-card.html project=project %}
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <div class="section-grid">
+    <section class="info-card">
+      <h2>About the site</h2>
+      <p>
+        You can find things that I'm working on, things that I've done, and my resume here.
+        I try to keep it up to date, but it may still be a bit behind what I'm actually up to.
+      </p>
+      <p>
+        While it may not seem like much, it's enough for me to call home :)
+      </p>
+    </section>
+
+    <section class="info-card">
+      <h2>What I keep coming back to</h2>
+      <ul class="tag-list">
+        <li>Coding</li>
+        <li>Video games</li>
+        <li>Mechanical keyboards</li>
+        <li>PC building</li>
+        <li>Journaling</li>
+        <li>Small tools</li>
+      </ul>
+    </section>
+  </div>
 </div>

--- a/projects.html
+++ b/projects.html
@@ -4,9 +4,9 @@ title: Projects
 permalink: /projects/
 ---
 
-{% assign current_project_titles = "Copilot Bridge|Mineless|Circles" | split: "|" %}
-{% assign selected_project_titles = "Windows App Restarter|YouTube Summarizer with Gemini|The Mighty Architectury|GluChart" | split: "|" %}
-{% assign hidden_project_titles = "Career Expo Project" | split: "|" %}
+{% assign current_project_titles = site.data.project_groups.current %}
+{% assign selected_project_titles = site.data.project_groups.selected %}
+{% assign hidden_project_titles = site.data.project_groups.hidden %}
 {% assign current_start_year = "" %}
 {% assign current_end_year = "" %}
 {% for project_title in current_project_titles %}

--- a/projects.html
+++ b/projects.html
@@ -55,17 +55,29 @@ permalink: /projects/
 {% capture archive_year_hint %}{% if archive_start_year == archive_end_year %}{{ archive_start_year }}{% else %}{{ archive_start_year }}-{{ archive_end_year }}{% endif %}{% endcapture %}
 
 <div class="content projects-page">
-  <div class="section wide">
-    <h1>Projects</h1>
+  <div class="section wide page-hero">
+    <p class="eyebrow">Work archive</p>
+    <h1>Projects.</h1>
+    <p class="lede">
+      Things I am actively building, finished or stable work that still feels representative,
+      and older projects I want to keep around.
+    </p>
+    <nav class="jump-nav" aria-label="Project sections">
+      <a href="#current">Current</a>
+      <a href="#selected-work">Selected Work</a>
+      <a href="#archive">Archive</a>
+    </nav>
   </div>
 
-  <div class="section wide project-section">
-    <div class="project-section__row">
-      <h2>Current</h2>
-      <span class="project-section__hint">{{ current_year_hint }}</span>
-    </div>
-    <p>Things I am actively building, shaping, using, or deciding the future of.</p>
-  </div>
+  <section id="current" class="section wide page-section project-section">
+    <header class="section-head">
+      <div class="section-head__row">
+        <h2 class="section-head__title">Current</h2>
+        <span class="section-head__hint">{{ current_year_hint }}</span>
+      </div>
+      <p>Things I am actively building, shaping, using, or deciding the future of.</p>
+    </header>
+  </section>
   <div class="projects">
     {% for project_title in current_project_titles %}
       {% assign project = site.posts | where: "title", project_title | first %}
@@ -75,13 +87,15 @@ permalink: /projects/
     {% endfor %}
   </div>
 
-  <div class="section wide project-section">
-    <div class="project-section__row">
-      <h2>Selected Work</h2>
-      <span class="project-section__hint">{{ selected_year_hint }}</span>
-    </div>
-    <p>Finished or stable projects that still feel representative of what I like to make.</p>
-  </div>
+  <section id="selected-work" class="section wide page-section project-section">
+    <header class="section-head">
+      <div class="section-head__row">
+        <h2 class="section-head__title">Selected Work</h2>
+        <span class="section-head__hint">{{ selected_year_hint }}</span>
+      </div>
+      <p>Finished or stable projects that still feel representative of what I like to make.</p>
+    </header>
+  </section>
   <div class="projects">
     {% for project_title in selected_project_titles %}
       {% assign project = site.posts | where: "title", project_title | first %}
@@ -91,13 +105,15 @@ permalink: /projects/
     {% endfor %}
   </div>
 
-  <div class="section wide project-section">
-    <div class="project-section__row">
-      <h2>Archive</h2>
-      <span class="project-section__hint">{{ archive_year_hint }}</span>
-    </div>
-    <p>Older, smaller, or more nostalgic things I still want to keep around.</p>
-  </div>
+  <section id="archive" class="section wide page-section project-section">
+    <header class="section-head">
+      <div class="section-head__row">
+        <h2 class="section-head__title">Archive</h2>
+        <span class="section-head__hint">{{ archive_year_hint }}</span>
+      </div>
+      <p>Older, smaller, or more nostalgic things I still want to keep around.</p>
+    </header>
+  </section>
   <div class="projects">
     {% for post in site.posts %}
       {% unless current_project_titles contains post.title or selected_project_titles contains post.title or hidden_project_titles contains post.title %}

--- a/resume.html
+++ b/resume.html
@@ -6,32 +6,73 @@ permalink: /resume/
 
 <div class="content resume-page">
   <div class="section wide page-hero">
-    <p class="eyebrow">Formal view</p>
+    <p class="eyebrow">One page / formal version</p>
     <h1>Resume.</h1>
     <p class="lede">
-      I keep the formal version as a PDF so it is easy to share, print, or send along.
+      The short, shareable version of what I've built and where. The longer,
+      less formal version lives on the <a href="{{ "/projects" | relative_url }}">Projects page</a>.
     </p>
   </div>
 
-  <div class="section wide resume-card">
-    <div>
-      <p class="resume-card__kicker">PDF resume</p>
-      <h2>The concise version.</h2>
+  <section class="section wide page-section" aria-labelledby="pdf-title">
+    <header class="section-head">
+      <h2 id="pdf-title" class="section-head__title">The PDF</h2>
+      <p>I keep the formal version as a PDF so it is easy to share, print, or send along.</p>
+    </header>
+
+    <div class="resume-card">
+      <div>
+        <p class="resume-card__kicker">PDF resume</p>
+        <h3>Tim Stewart - Resume</h3>
+        <p>
+          Use this when you need the traditional document. It opens in a new tab,
+          and there is a download link if you want a local copy.
+        </p>
+      </div>
+      <div class="resume-card__actions">
+        <a class="button-link" href="{{ "/assets/Resume.pdf" | relative_url }}" target="_blank" rel="noreferrer noopener">View resume PDF</a>
+        <a class="button-link button-link--secondary" href="{{ "/assets/Resume.pdf" | relative_url }}" download>Download PDF</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wide page-section" aria-labelledby="expect-title">
+    <header class="section-head">
+      <h2 id="expect-title" class="section-head__title">What to expect</h2>
+      <p>So you know what kind of document you are opening.</p>
+    </header>
+
+    <div class="preview-grid">
+      <div class="preview">
+        <span class="preview__num">01</span>
+        <span class="preview__title">Experience</span>
+        <span class="preview__detail">Roles, dates, and the work most relevant to software engineering.</span>
+      </div>
+      <div class="preview">
+        <span class="preview__num">02</span>
+        <span class="preview__title">Education</span>
+        <span class="preview__detail">The formal background behind the project work on this site.</span>
+      </div>
+      <div class="preview">
+        <span class="preview__num">03</span>
+        <span class="preview__title">Skills</span>
+        <span class="preview__detail">Languages, tools, and stacks I am comfortable working with.</span>
+      </div>
+      <div class="preview">
+        <span class="preview__num">04</span>
+        <span class="preview__title">Projects</span>
+        <span class="preview__detail">The compact version; Projects has the more personal context.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="section wide page-section">
+    <div class="nudge-card">
+      <span class="nudge-card__label">Friendly nudge</span>
+      <h2>Projects is the less formal picture.</h2>
       <p>
-        Use this when you need the traditional document. It opens in a new tab,
-        and there is a download link if you want a local copy.
+        The resume is useful, but the <a href="{{ "/projects" | relative_url }}">Projects</a> page is a better view of what I like making and why.
       </p>
     </div>
-    <div class="resume-card__actions">
-      <a class="button-link" href="{{ "/assets/Resume.pdf" | relative_url }}" target="_blank" rel="noreferrer noopener">View resume PDF</a>
-      <a class="button-link button-link--secondary" href="{{ "/assets/Resume.pdf" | relative_url }}" download>Download PDF</a>
-    </div>
-  </div>
-
-  <div class="section wide nudge-card">
-    <h2>Projects is the less formal picture.</h2>
-    <p>
-      The resume is useful, but the <a href="{{ "/projects" | relative_url }}">Projects</a> page is a better view of what I like making and why.
-    </p>
-  </div>
+  </section>
 </div>

--- a/resume.html
+++ b/resume.html
@@ -4,19 +4,34 @@ title: Resume
 permalink: /resume/
 ---
 
-<div class="content">
-  <div class="section wide">
-    <h1>Resume</h1>
-    <p>
+<div class="content resume-page">
+  <div class="section wide page-hero">
+    <p class="eyebrow">Formal view</p>
+    <h1>Resume.</h1>
+    <p class="lede">
       I keep the formal version as a PDF so it is easy to share, print, or send along.
     </p>
+  </div>
+
+  <div class="section wide resume-card">
+    <div>
+      <p class="resume-card__kicker">PDF resume</p>
+      <h2>The concise version.</h2>
+      <p>
+        Use this when you need the traditional document. It opens in a new tab,
+        and there is a download link if you want a local copy.
+      </p>
+    </div>
+    <div class="resume-card__actions">
+      <a class="button-link" href="{{ "/assets/Resume.pdf" | relative_url }}" target="_blank" rel="noreferrer noopener">View resume PDF</a>
+      <a class="button-link button-link--secondary" href="{{ "/assets/Resume.pdf" | relative_url }}" download>Download PDF</a>
+    </div>
+  </div>
+
+  <div class="section wide nudge-card">
+    <h2>Projects is the less formal picture.</h2>
     <p>
-      <a href="{{ "/assets/Resume.pdf" | relative_url }}" target="_blank" rel="noreferrer noopener">View resume PDF</a>
-      <span aria-hidden="true">/</span>
-      <a href="{{ "/assets/Resume.pdf" | relative_url }}" download>Download PDF</a>
-    </p>
-    <p>
-      For a less formal picture of what I make, the <a href="{{ "/projects" | relative_url }}">Projects</a> page is more useful.
+      The resume is useful, but the <a href="{{ "/projects" | relative_url }}">Projects</a> page is a better view of what I like making and why.
     </p>
   </div>
 </div>

--- a/social.html
+++ b/social.html
@@ -5,66 +5,79 @@ title: Socials
 
 <div class="content social-page">
   <div class="section wide page-hero">
-    <p class="eyebrow">Links</p>
+    <p class="eyebrow">Find me / five places</p>
     <h1>Social.</h1>
-    <p class="lede">A few places to find me around the internet.</p>
+    <p class="lede">
+      A few places I post, build, or hang out. Code on GitHub, professional
+      notes on LinkedIn, and the rest is more casual.
+    </p>
   </div>
 
-  <div class="section wide social-list" aria-labelledby="social-links-title">
+  <section class="section wide page-section" aria-labelledby="social-links-title">
     <h2 id="social-links-title" class="visually-hidden">Profiles</h2>
-    <a class="social-row" href="https://github.com/TimStewartJ" target="_blank" rel="noreferrer noopener">
-      <span class="social-row__main">
-        <span class="social-row__top">
-          <span class="social-row__name">GitHub</span>
-          <span class="social-row__handle">@TimStewartJ</span>
+    <div class="social-list">
+      <a class="social-row" href="https://github.com/TimStewartJ" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__main">
+          <span class="social-row__top">
+            <span class="social-row__name">GitHub</span>
+            <span class="social-row__handle">@TimStewartJ</span>
+          </span>
+          <span class="social-row__note">Code, project repos, and the occasional work-in-progress.</span>
         </span>
-        <span class="social-row__note">Code, project repos, and the occasional work-in-progress.</span>
-      </span>
-      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
-    </a>
+        <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+      </a>
 
-    <a class="social-row" href="https://www.linkedin.com/in/timstewartj/" target="_blank" rel="noreferrer noopener">
-      <span class="social-row__main">
-        <span class="social-row__top">
-          <span class="social-row__name">LinkedIn</span>
-          <span class="social-row__handle">/in/timstewartj</span>
+      <a class="social-row" href="https://www.linkedin.com/in/timstewartj/" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__main">
+          <span class="social-row__top">
+            <span class="social-row__name">LinkedIn</span>
+            <span class="social-row__handle">/in/timstewartj</span>
+          </span>
+          <span class="social-row__note">Professional history, work timeline, and connections. The formal version of all this.</span>
         </span>
-        <span class="social-row__note">The professional version: work history, connections, and resume-adjacent things.</span>
-      </span>
-      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
-    </a>
+        <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+      </a>
 
-    <a class="social-row" href="https://instagram.com/timstewartj/" target="_blank" rel="noreferrer noopener">
-      <span class="social-row__main">
-        <span class="social-row__top">
-          <span class="social-row__name">Instagram</span>
-          <span class="social-row__handle">@timstewartj</span>
+      <a class="social-row" href="https://instagram.com/timstewartj/" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__main">
+          <span class="social-row__top">
+            <span class="social-row__name">Instagram</span>
+            <span class="social-row__handle">@timstewartj</span>
+          </span>
+          <span class="social-row__note">A more personal place for photos, hobbies, and things I want to remember.</span>
         </span>
-        <span class="social-row__note">A more personal place for photos, hobbies, and things I want to remember.</span>
-      </span>
-      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
-    </a>
+        <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+      </a>
 
-    <a class="social-row" href="https://www.youtube.com/channel/UCe95ZA30ro1-ANQyO1wXVzA" target="_blank" rel="noreferrer noopener">
-      <span class="social-row__main">
-        <span class="social-row__top">
-          <span class="social-row__name">YouTube</span>
-          <span class="social-row__handle">Channel</span>
+      <a class="social-row" href="https://www.youtube.com/channel/UCe95ZA30ro1-ANQyO1wXVzA" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__main">
+          <span class="social-row__top">
+            <span class="social-row__name">YouTube</span>
+            <span class="social-row__handle">Channel</span>
+          </span>
+          <span class="social-row__note">Videos, demos, or experiments when I have something worth posting.</span>
         </span>
-        <span class="social-row__note">Videos, demos, or experiments when I have something worth posting.</span>
-      </span>
-      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
-    </a>
+        <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+      </a>
 
-    <a class="social-row" href="https://discord.com/users/372696487290863618" target="_blank" rel="noreferrer noopener">
-      <span class="social-row__main">
-        <span class="social-row__top">
-          <span class="social-row__name">Discord</span>
-          <span class="social-row__handle">.timmie.</span>
+      <a class="social-row" href="https://discord.com/users/372696487290863618" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__main">
+          <span class="social-row__top">
+            <span class="social-row__name">Discord</span>
+            <span class="social-row__handle">.timmie.</span>
+          </span>
+          <span class="social-row__note">Where I am easiest to recognize if we already share a server.</span>
         </span>
-        <span class="social-row__note">Where I am easiest to recognize if we already share a server.</span>
-      </span>
-      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
-    </a>
-  </div>
+        <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+      </a>
+    </div>
+
+    <aside class="aside-note">
+      <span class="aside-note__label">Other ways</span>
+      <p>
+        Not on any of these but want to reach out about a project? Opening an issue on
+        the relevant <a href="https://github.com/TimStewartJ">GitHub repo</a> works too.
+      </p>
+    </aside>
+  </section>
 </div>

--- a/social.html
+++ b/social.html
@@ -3,23 +3,68 @@ layout: default
 title: Socials
 ---
 
-<link
-  rel="stylesheet"
-  href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
-  integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm"
-  crossorigin="anonymous"
-/>
+<div class="content social-page">
+  <div class="section wide page-hero">
+    <p class="eyebrow">Links</p>
+    <h1>Social.</h1>
+    <p class="lede">A few places to find me around the internet.</p>
+  </div>
 
-<div class="content">
-  <div class="section social">
-    <h1>My Socials</h1>
-    <p>All links will redirect to a new tab.</p>
-    <a href="https://github.com/TimStewartJ" target="_blank" rel="noreferrer noopener"> <i class="fab fa-github"></i> Github </a>
-    <a href="https://www.linkedin.com/in/timstewartj/" target="_blank" rel="noreferrer noopener"> <i class="fab fa-linkedin"></i> LinkedIn </a>
-    <a href="https://instagram.com/timstewartj/" target="_blank" rel="noreferrer noopener"> <i class="fab fa-instagram"></i> Instagram </a>
-    <a href="https://www.youtube.com/channel/UCe95ZA30ro1-ANQyO1wXVzA" target="_blank" rel="noreferrer noopener">
-      <i class="fab fa-youtube"></i> YouTube
+  <div class="section wide social-list" aria-labelledby="social-links-title">
+    <h2 id="social-links-title" class="visually-hidden">Profiles</h2>
+    <a class="social-row" href="https://github.com/TimStewartJ" target="_blank" rel="noreferrer noopener">
+      <span class="social-row__main">
+        <span class="social-row__top">
+          <span class="social-row__name">GitHub</span>
+          <span class="social-row__handle">@TimStewartJ</span>
+        </span>
+        <span class="social-row__note">Code, project repos, and the occasional work-in-progress.</span>
+      </span>
+      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
     </a>
-    <a href="https://discord.com/users/372696487290863618" target="_blank" rel="noreferrer noopener"> <i class="fab fa-discord"></i> .timmie. </a>
+
+    <a class="social-row" href="https://www.linkedin.com/in/timstewartj/" target="_blank" rel="noreferrer noopener">
+      <span class="social-row__main">
+        <span class="social-row__top">
+          <span class="social-row__name">LinkedIn</span>
+          <span class="social-row__handle">/in/timstewartj</span>
+        </span>
+        <span class="social-row__note">The professional version: work history, connections, and resume-adjacent things.</span>
+      </span>
+      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+    </a>
+
+    <a class="social-row" href="https://instagram.com/timstewartj/" target="_blank" rel="noreferrer noopener">
+      <span class="social-row__main">
+        <span class="social-row__top">
+          <span class="social-row__name">Instagram</span>
+          <span class="social-row__handle">@timstewartj</span>
+        </span>
+        <span class="social-row__note">A more personal place for photos, hobbies, and things I want to remember.</span>
+      </span>
+      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+    </a>
+
+    <a class="social-row" href="https://www.youtube.com/channel/UCe95ZA30ro1-ANQyO1wXVzA" target="_blank" rel="noreferrer noopener">
+      <span class="social-row__main">
+        <span class="social-row__top">
+          <span class="social-row__name">YouTube</span>
+          <span class="social-row__handle">Channel</span>
+        </span>
+        <span class="social-row__note">Videos, demos, or experiments when I have something worth posting.</span>
+      </span>
+      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+    </a>
+
+    <a class="social-row" href="https://discord.com/users/372696487290863618" target="_blank" rel="noreferrer noopener">
+      <span class="social-row__main">
+        <span class="social-row__top">
+          <span class="social-row__name">Discord</span>
+          <span class="social-row__handle">.timmie.</span>
+        </span>
+        <span class="social-row__note">Where I am easiest to recognize if we already share a server.</span>
+      </span>
+      <span class="social-row__arrow" aria-hidden="true">&nearr;</span>
+    </a>
   </div>
 </div>

--- a/social.html
+++ b/social.html
@@ -3,6 +3,13 @@ layout: default
 title: Socials
 ---
 
+<link
+  rel="stylesheet"
+  href="https://use.fontawesome.com/releases/v5.15.4/css/all.css"
+  integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm"
+  crossorigin="anonymous"
+/>
+
 <div class="content social-page">
   <div class="section wide page-hero">
     <p class="eyebrow">Find me / five places</p>
@@ -17,6 +24,7 @@ title: Socials
     <h2 id="social-links-title" class="visually-hidden">Profiles</h2>
     <div class="social-list">
       <a class="social-row" href="https://github.com/TimStewartJ" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__icon" aria-hidden="true"><i class="fab fa-github"></i></span>
         <span class="social-row__main">
           <span class="social-row__top">
             <span class="social-row__name">GitHub</span>
@@ -28,6 +36,7 @@ title: Socials
       </a>
 
       <a class="social-row" href="https://www.linkedin.com/in/timstewartj/" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__icon" aria-hidden="true"><i class="fab fa-linkedin"></i></span>
         <span class="social-row__main">
           <span class="social-row__top">
             <span class="social-row__name">LinkedIn</span>
@@ -39,6 +48,7 @@ title: Socials
       </a>
 
       <a class="social-row" href="https://instagram.com/timstewartj/" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__icon" aria-hidden="true"><i class="fab fa-instagram"></i></span>
         <span class="social-row__main">
           <span class="social-row__top">
             <span class="social-row__name">Instagram</span>
@@ -50,6 +60,7 @@ title: Socials
       </a>
 
       <a class="social-row" href="https://www.youtube.com/channel/UCe95ZA30ro1-ANQyO1wXVzA" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__icon" aria-hidden="true"><i class="fab fa-youtube"></i></span>
         <span class="social-row__main">
           <span class="social-row__top">
             <span class="social-row__name">YouTube</span>
@@ -61,6 +72,7 @@ title: Socials
       </a>
 
       <a class="social-row" href="https://discord.com/users/372696487290863618" target="_blank" rel="noreferrer noopener">
+        <span class="social-row__icon" aria-hidden="true"><i class="fab fa-discord"></i></span>
         <span class="social-row__main">
           <span class="social-row__top">
             <span class="social-row__name">Discord</span>


### PR DESCRIPTION
## Summary
- refresh the Home page with a masthead-style intro, meta strip, current-project teasers, and interest cards
- move project groups into `_data/project_groups.yml` so Home and Projects share the same source of truth
- redesign Social as link rows using the real existing URLs/handles
- redesign Resume around a PDF action card and Projects nudge
- add a guarded project-detail meta strip and body wrapper without duplicating post titles

## Validation
- Built with Docker Ruby: `bundle exec jekyll build`
- Checked generated local links/assets resolve under `_site`
- Inspected Home, Projects, Social, Resume, and Circles pages at desktop and mobile widths
- Ran a focused code-review pass for Liquid, links, accessibility, content drift, and responsive/CSS regressions